### PR TITLE
Handle BlockVision API failures gracefully

### DIFF
--- a/.github/workflows/sui_portfolio_V3.yml
+++ b/.github/workflows/sui_portfolio_V3.yml
@@ -24,7 +24,7 @@ jobs:
           if [ -z "${{ secrets.BLOCKVISION_API_KEY }}" ]; then
             echo "BLOCKVISION_API_KEY is MISSING"; exit 1; fi
           echo "BLOCKVISION_API_KEY is set ✅"
-      - name: Sanity ping BlockVision (200 expected)
+      - name: Sanity ping BlockVision
         env:
           ADDR1: '0x9e10f69f6475bcb01fb2117facd665c68483da2cdefa6a681fa6a874af0df165'
           ADDR2: '0xa63ef51b8abf601fb40d8514050a8d5613c0509d4b36323dc4439ee6c69d704e'
@@ -36,7 +36,9 @@ jobs:
               -H "User-Agent: sui-portfolio-bot/1.0 (+github-actions)" \
               "https://api.blockvision.org/v2/sui/account/defiPortfolio?address=$A")
             echo "BlockVision status for $A: $CODE"
-            if [ "$CODE" != "200" ]; then echo "BlockVision returned $CODE"; exit 1; fi
+            if [ "$CODE" != "200" ]; then
+              echo "Warning: BlockVision returned $CODE for $A"
+            fi
           done
 
       # 1) Pull DeFi portfolio (SuiVision backend via BlockVision API)


### PR DESCRIPTION
## Summary
- let the BlockVision sanity ping warn instead of exiting

## Testing
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile scripts/fetch_defi_blockvision.py`


------
https://chatgpt.com/codex/tasks/task_e_68a825074e6483269b131dc3dcc395f5